### PR TITLE
Fix - Click en icono de reacciones

### DIFF
--- a/src/views/Chat/index.js
+++ b/src/views/Chat/index.js
@@ -333,7 +333,7 @@ export default function Chat() {
     }
   }
 
-  const handleReactionClick = idComment => setViewReactions(idComment)
+  const handleReactionClick = idComment => viewReactions ? setViewReactions(false) : setViewReactions(idComment)
 
   function handleClickIcons(e, val) {
     const addComments = [...comments, {idComment: Math.random() * (100000 - 1) + 1,strComment: val}]

--- a/src/views/Chat/index.js
+++ b/src/views/Chat/index.js
@@ -333,7 +333,7 @@ export default function Chat() {
     }
   }
 
-  const handleReactionClick = idComment => viewReactions ? setViewReactions(false) : setViewReactions(idComment)
+  const handleReactionClick = idComment => setViewReactions(idComment)
 
   function handleClickIcons(e, val) {
     const addComments = [...comments, {idComment: Math.random() * (100000 - 1) + 1,strComment: val}]

--- a/src/views/Chat/index.js
+++ b/src/views/Chat/index.js
@@ -333,6 +333,8 @@ export default function Chat() {
     }
   }
 
+  const handleReactionClick = idComment => viewReactions ? setViewReactions(false) : setViewReactions(idComment)
+
   function handleClickIcons(e, val) {
     const addComments = [...comments, {idComment: Math.random() * (100000 - 1) + 1,strComment: val}]
     setComments(addComments)
@@ -370,14 +372,14 @@ export default function Chat() {
                 <div className={styles.wrapComment}>
                   <div className={styles.reaction}>
                     {/* FIXME: 3: Mostrar popUp de reacciones y asignar un areaccion a comentario */}
-                    {viewReactions && (
+                    {viewReactions === idComment && (
                       <div className={styles.reactionSelector}>
                         {REACTIONS_LIST.map((icon) => {
                           return <div className={styles.iReaction} onClick={(e)=>handleReaction(e,idComment)}>{icon}</div>;
                         })}
                       </div>
                     )}
-                    <div className={styles.iconsReaction} onClick={() => setViewReactions(!viewReactions)}>
+                    <div className={styles.iconsReaction} onClick={() => handleReactionClick(idComment)}>
                     😀
                     </div>
                   </div>


### PR DESCRIPTION
Ahora si, al picarle al icono solo se despliegan las reacciones para ese mensaje.

![Una captura](https://user-images.githubusercontent.com/61762222/107839739-97c70000-6d73-11eb-8c2e-60f899431853.png)
`